### PR TITLE
docs(github): remove bad relative path in pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,4 +31,4 @@ Please makes sure that these forms are filled before submitting your pull reques
 ## ☑️ Self Check before Merge
 
 - [ ] Doc is updated/provided or not needed
-- [ ] Followed the code rule listed in [README.md](../README.md#code-rules)
+- [ ] Followed the code rule listed in README.md


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

## 🤔 This is a ...

- [ ] New feature
- [x] Site / document update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

## 🔗 Related Issue Link

<!--
1. Describe the source of requirement, like related issue link.
2. Leave blank if no related issue link.
-->

## 💡 Background and Solution
Can not link to the README file with a relative path in the PR template, so decide to remove the link.
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if it includes UI/interactive modification.
3. How to fix the problem and list the final API implementation and usage sample if that is a new feature.
-->

## ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Followed the code rule listed in [README.md](../README.md#code-rules)